### PR TITLE
corrects spelling in readme & settings file, also removes lib/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ pseudo-code/
 lib_old/
 spec_old/
 keymaps_old/
-lib/

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ Command Palette ➔ Settings View: Install Packages ➔ Break
   - *Enable Notifications* - boolean :
   Get a notification 1 minute before each macro break
   - *Duration* - integer :
-  Duration in minites of each macro break
+  Duration in minutes of each macro break
   - *Interval* - integer :
-  Time in minites between each macro break
+  Time in minutes between each macro break
 - **Micro Break Configuration**
   - *Enable Notifications* - boolean :
   Get a notification 1 minute before each micro break
   - *Duration* - integer :
-  Duration in minites of each micro break
+  Duration in minutes of each micro break
   - *Interval* - integer :
-  Time in minites between each micro break
+  Time in minutes between each micro break
   - *Amount* - integer :
   Amount of micro breaks before the macro break starts
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -27,7 +27,7 @@ export default {
                 },
                 duration: {
                     title: 'Duration',
-                    description: 'Duration in minites of each macro break',
+                    description: 'Duration in minutes of each macro break',
                     type: 'integer',
                     default: 10,
                     minimum: 1,
@@ -36,7 +36,7 @@ export default {
                 },
                 interval: {
                     title: 'Interval',
-                    description: 'Time in minites between each macro break',
+                    description: 'Time in minutes between each macro break',
                     type: 'integer',
                     default: 60,
                     minimum: 2,
@@ -60,7 +60,7 @@ export default {
                 },
                 duration: {
                     title: 'Duration',
-                    description: 'Duration in minites of each micro break',
+                    description: 'Duration in minutes of each micro break',
                     type: 'integer',
                     default: 5,
                     minimum: 1,
@@ -69,7 +69,7 @@ export default {
                 },
                 interval: {
                     title: 'Interval',
-                    description: 'Time in minites between each mico break',
+                    description: 'Time in minutes between each micro break',
                     type: 'integer',
                     default: 30,
                     minimum: 2,


### PR DESCRIPTION
Hello! I was changing the settings for break in atom today, and noticed a few small spelling errors in the settings, which were also present in the readme. I've corrected them here, but also had to remove the `lib` folder from .gitignore, as the changes needed to take place in the settings filed stored there.